### PR TITLE
Use core stream.Transform if 0.9+

### DIFF
--- a/through2.js
+++ b/through2.js
@@ -1,4 +1,4 @@
-const Transform = require('readable-stream/transform')
+const Transform = require('stream').Transform || require('readable-stream/transform')
     , inherits  = require('util').inherits
 
 function Through2 (options, transform, flush) {


### PR DESCRIPTION
Awesome library, already shaving some boilerplate off of some of my work!

I noticed you aren't using the core stream.Transform, which tends to get bug fixes where the [readable-stream](http://npm.im/readable-stream) 0.8 compatability layer is pretty much dormant.

This patch simply uses the core version if it is there, otherwise sticks to the npm library.

Tested on 0.8.24 and 0.10.15 (with triggers to inform me which was being used)
