### PR TITLE
Do not create a new prototype everytime make is called

### DIFF
--- a/through2.js
+++ b/through2.js
@@ -35,7 +35,23 @@ function ctor (options, transform, flush) {
 }
 
 function make (options, transform, flush) {
-  return ctor(options, transform, flush)()
+  if (typeof options == 'function') {
+    flush     = transform
+    transform = options
+    options   = {}
+  }
+
+  if (typeof transform != 'function')
+    transform = noop
+
+  var through2 = new Transform(options)
+
+  through2._transform = transform
+
+  if (typeof flush == 'function')
+    through2._flush = flush
+
+  return through2;
 }
 
 module.exports      = make


### PR DESCRIPTION
Great module!

Currently make will create a new prototype and throw it away everytime it's called. 
This PR changes this by just using `new stream.Transform()` in make and then overriding `._transform` and `._flush` afterwards. This leads to much faster instantiation time (10x faster in my benchmarks).
