### PR TITLE
through2.obj()

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var all = []
 
 fs.createReadStream('data.csv')
   .pipe(csv2())
-  .pipe(through2({ objectMode: true }, function (chunk, enc, callback) {
+  .pipe(through2.obj(function (chunk, enc, callback) {
 
     var data = {
         name    : chunk[0]
@@ -67,6 +67,8 @@ fs.createReadStream('data.csv')
   })
 ```
 
+Note that `through2.obj(fn)` is a convenience wrapper around `through2({ objectMode: true }, fn)`.
+
 ## API
 
 <b><code>through2([ options, ] [ transformFunction ] [, flushFunction ])</code></b>
@@ -75,7 +77,7 @@ Consult the **[stream.Transform](http://nodejs.org/docs/latest/api/stream.html#s
 
 ### options
 
-The options argument is optional and is passed straight through to `stream.Transform`. So you can use `objectMode:true` if you are processing non-binary streams.
+The options argument is optional and is passed straight through to `stream.Transform`. So you can use `objectMode:true` if you are processing non-binary streams (or just use `through2.obj()`).
 
 The `options` argument is first, unlike standard convention, because if I'm passing in an anonymous function then I'd prefer for the options argument to not get lost at the end of the call:
 

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -78,6 +78,26 @@ test('object through', function (t) {
   th2.end()
 })
 
+test('object through with through2.obj', function (t) {
+  t.plan(3)
+
+  var th2 = through2.obj(function (chunk, enc, callback) {
+    this.push({ out: chunk.in + 1 })
+    callback()
+  })
+
+  var e = 0
+  th2.on('data', function (o) {
+    t.deepEqual(o, { out: e === 0 ? 102 : e == 1 ? 203 : -99 }, 'got transformed object')
+    e++
+  })
+
+  th2.write({ in: 101 })
+  th2.write({ in: 202 })
+  th2.write({ in: -100 })
+  th2.end()
+})
+
 test('flushing through', function (t) {
   var th2 = through2(function (chunk, enc, callback) {
     if (!this._i)

--- a/through2.js
+++ b/through2.js
@@ -64,3 +64,14 @@ module.exports.ctor = through2(function (options, transform, flush) {
 
   return Through2
 })
+
+module.exports.obj = through2(function (options, transform, flush) {
+  var t2 = new Transform(xtend({ objectMode: true }, options))
+
+  t2._transform = transform
+
+  if (flush)
+    t2._flush = flush
+
+  return t2
+})


### PR DESCRIPTION
Time to make a `through2.obj()`? How does this look. There's no `ctor` equiv, I'm not sure that's required as I'm guessing it's the less-used form.
