### PR TITLE
Set highWaterMark to 16 in objectMode

### DIFF
--- a/through2.js
+++ b/through2.js
@@ -67,7 +67,7 @@ module.exports.ctor = through2(function (options, transform, flush) {
 
 
 module.exports.obj = through2(function (options, transform, flush) {
-  var t2 = new Transform(xtend({ objectMode: true }, options))
+  var t2 = new Transform(xtend({ objectMode: true, highWaterMark: 16 }, options))
 
   t2._transform = transform
 


### PR DESCRIPTION
Currently in node 0.10 hwm defaults to ~16000 objects when streaming in objectMode which means that backpressure will almost never happen.

This is fixed in node 0.12 where it will default to 16 in objectMode.
We can fix this now in through2 by merging this PR :)
