### PR TITLE
Import `(readable-stream).Transform` and use stream-browserify in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.5.1",
   "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
   "main": "through2.js",
+  "browser": {
+    "readable-stream": "stream-browserify"
+  },
   "scripts": {
     "test": "node test/test.js",
     "test-local": "brtapsauce-local test/basic-test.js"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "readable-stream": "~1.0.17",
+    "stream-browserify": "^1.0.0",
     "xtend": "~3.0.0"
   },
   "devDependencies": {

--- a/through2.js
+++ b/through2.js
@@ -1,4 +1,4 @@
-var Transform = require('readable-stream/transform')
+var Transform = require('readable-stream').Transform
   , inherits  = require('util').inherits
   , xtend     = require('xtend')
 


### PR DESCRIPTION
Please see this reduced test case of an oddity I ran into this evening. I could really use your advice.

https://github.com/gobengo/chronos-stream-dependant

Without this patch, whenever I would require through2, it would break completely separate parts of my dependency tree that were using readable-stream.

If you look at this and help out, thank you so much!

(great lib)
