### PR TITLE
document callback logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The `transformFunction` must have the following signature: `function (chunk, enc
 
 To queue a new chunk, call `this.push(chunk)`&mdash;this can be called as many times as required before the `callback()` if you have multiple pieces to send on.
 
+Alternatively, you may use `callback(err, chunk)` as shorthand for emitting a single chunk or an error.
+
 If you **do not provide a `transformFunction`** then you will get a simple pass-through stream.
 
 ### flushFunction


### PR DESCRIPTION
It doesn't seem like this is documented anywhere in the core docs either, but this behaviour works and saves a few lines of code on simple transforms, and also makes it really easy to use other standard async modules with through2
