### PR TITLE
add .destroy method

### DIFF
--- a/through2.js
+++ b/through2.js
@@ -4,14 +4,14 @@ var Transform = require('readable-stream/transform')
 
 function DestroyableTransform(opts) {
   Transform.call(this, opts)
-  this.destroyed = false
+  this._destroyed = false
 }
 
 inherits(DestroyableTransform, Transform)
 
 DestroyableTransform.destroy = function(err) {
-  if (this.destroyed) return
-  this.destroyed = true
+  if (this._destroyed) return
+  this._destroyed = true
   
   var self = this
   process.nextTick(function() {


### PR DESCRIPTION
Similarly to the old through module (and many other stream modules) this adds a `.destroy()` method that emits close on the next tick.

This allow you to easier add teardown logic

``` js
var makeStream = function() {
  var stream = through2(...)
  stream.on('close', function() {
    // in case stream was destroyed cleanup
  })
  return stream
}

var s = makeStream()
...
s.destroy() // something went bad - destroy the stream
```
