### PR TITLE
bump to streams3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
   "license": "MIT",
   "dependencies": {
-    "readable-stream": ">=1.0.33-1 <1.1.0-0",
+    "readable-stream": ">=1.1.13 <1.2.0",
     "xtend": ">=4.0.0 <4.1.0-0"
   },
   "devDependencies": {


### PR DESCRIPTION
since both iojs and node 0.12 is on streams3 shouldn't this be as well?