### PR TITLE
adds coverage reporting using nyc and coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+coverage
+nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 coverage
-nyc_output
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ env:
   global:
   - SAUCE_USER=through2-sauce
   - secure: A8KyygIlklZOcTwTGhZHpkOu7Cn4tI1QQasg75CTSjudczGzkuh1pG2RDIkWqGcrWv9o5CjI6fFYYx0JvQu8o5PO+ZAtV1Z0AlnM965vE8kAx0XEC7giAV323bibfnHwyQu74vIhbOfdes7E4/cYerV2kAjK0T375D4DYEpDuvw=
-
+after_success: npm run coveralls

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
   "main": "through2.js",
   "scripts": {
-    "test": "node test/test.js | faucet",
-    "test-local": "brtapsauce-local test/basic-test.js"
+    "test": "node test/test.js",
+    "test-local": "brtapsauce-local test/basic-test.js",
+    "coverage": "nyc node test/basic-test.js && nyc report",
+    "coveralls": "nyc node test/basic-test.js && nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
   "main": "through2.js",
   "scripts": {
-    "test": "node test/test.js",
-    "test-local": "brtapsauce-local test/basic-test.js",
     "coverage": "nyc node test/basic-test.js && nyc report",
-    "coveralls": "nyc node test/basic-test.js && nyc report --reporter=text-lcov | coveralls"
+    "coveralls": "nyc node test/basic-test.js && nyc report --reporter=text-lcov | coveralls",
+    "test": "node test/test.js",
+    "test-local": "brtapsauce-local test/basic-test.js"
   },
   "repository": {
     "type": "git",
@@ -27,7 +27,9 @@
   },
   "devDependencies": {
     "bl": "~0.9.4",
+    "coveralls": "~2.11.3",
     "faucet": "0.0.1",
+    "nyc": "~3.0.0",
     "stream-spigot": "~3.0.5",
     "tape": "~4.0.0"
   }


### PR DESCRIPTION
This pull adds test coverage, facilitated by [nyc](https://www.npmjs.com/package/nyc) and the hosted coverage service coveralls.io.
- run `npm run coverage` to get a human readable coverage report.
- run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.
- run `npm run coveralls` to report coverage to the [coveralls.io](https://coveralls.io/).
  - you'll need to setup your repo on coveralls.io and grap the `COVERALLS_REPO_TOKEN`.
  - on travis-ci.org, you'll need to set an environment variable with the value of `COVERALLS_REPO_TOKEN`
