### PR TITLE
update deps for a proposed v2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
   "main": "through2.js",
   "scripts": {
-    "test": "node test/test.js",
+    "test": "node test/test.js | faucet",
     "test-local": "brtapsauce-local test/basic-test.js"
   },
   "repository": {
@@ -20,12 +20,13 @@
   "author": "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
   "license": "MIT",
   "dependencies": {
-    "readable-stream": ">=1.0.33-1 <1.1.0-0",
-    "xtend": ">=4.0.0 <4.1.0-0"
+    "readable-stream": "~2.0.0",
+    "xtend": "~4.0.0"
   },
   "devDependencies": {
-    "bl": ">=0.9.0 <0.10.0-0",
-    "stream-spigot": ">=3.0.4 <3.1.0-0",
-    "tape": ">=2.14.0 <2.15.0-0"
+    "bl": "~0.9.4",
+    "faucet": "0.0.1",
+    "stream-spigot": "~3.0.5",
+    "tape": "~4.0.0"
   }
 }


### PR DESCRIPTION
giving everyone a chance to object to a v2 release using readable-stream@2.0.0 which is the io.js streams3 implementation, this will finally become `@latest` in npm, no more streams2 default.