### PR TITLE
Update readable-stream dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
   "license": "MIT",
   "dependencies": {
-    "readable-stream": "^2.1.5",
+    "readable-stream": "^2.3.4",
     "xtend": "~4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
There was a [bug in `process-nextick-args`](https://github.com/calvinmetcalf/process-nextick-args/pull/10) where [`lolex` and `sinon`](https://github.com/sinonjs/lolex) fake timers didn't work as expected. [`readable-streams` updated their version of `process-nextick-args` to be after this fix was in place](https://github.com/nodejs/readable-stream/pull/320). The only thing needed at this point to get `through2` streams working with `lolex` now is to bump up it's version of `readable-streams`