### PR TITLE
Remove dependency xtend

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "author": "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
   "license": "MIT",
   "dependencies": {
-    "readable-stream": "2 || 3",
-    "xtend": "~4.0.1"
+    "readable-stream": "2 || 3"
   },
   "devDependencies": {
     "bl": "~2.0.1",

--- a/through2.js
+++ b/through2.js
@@ -84,7 +84,7 @@ module.exports.ctor = through2(function (options, transform, flush) {
 
 
 module.exports.obj = through2(function (options, transform, flush) {
-  var t2 = new DestroyableTransform(Object.assign({}, { objectMode: true, highWaterMark: 16 }, options))
+  var t2 = new DestroyableTransform(Object.assign({ objectMode: true, highWaterMark: 16 }, options))
 
   t2._transform = transform
 

--- a/through2.js
+++ b/through2.js
@@ -1,6 +1,5 @@
 var Transform = require('readable-stream').Transform
   , inherits  = require('util').inherits
-  , xtend     = require('xtend')
 
 function DestroyableTransform(opts) {
   Transform.call(this, opts)
@@ -68,7 +67,7 @@ module.exports.ctor = through2(function (options, transform, flush) {
     if (!(this instanceof Through2))
       return new Through2(override)
 
-    this.options = xtend(options, override)
+    this.options = Object.assign({}, options, override)
 
     DestroyableTransform.call(this, this.options)
   }
@@ -85,7 +84,7 @@ module.exports.ctor = through2(function (options, transform, flush) {
 
 
 module.exports.obj = through2(function (options, transform, flush) {
-  var t2 = new DestroyableTransform(xtend({ objectMode: true, highWaterMark: 16 }, options))
+  var t2 = new DestroyableTransform(Object.assign({}, { objectMode: true, highWaterMark: 16 }, options))
 
   t2._transform = transform
 


### PR DESCRIPTION
This removes the dependency `xtend` in favor of `Object.assign` which is available in Node 4+