### PR TITLE
require readable-stream@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
   "license": "MIT",
   "dependencies": {
-    "readable-stream": "2 || 3"
+    "readable-stream": "^3.0.0"
   },
   "devDependencies": {
     "bl": "~2.0.1",


### PR DESCRIPTION
This change would require readable-stream@3, instead of being okay with 2 or 3. The current workaround for a project is to depend on both through2@3 and readable-stream@3, but it seems easier for through2 to choose one version of readable-stream@3. Am I overlooking something with that idea?

Thank you for the library and considering!

(RE: https://github.com/googleapis/nodejs-storage/pull/799#issuecomment-519678551)