### PR TITLE
Patch: Using inherits package instead of node inherits.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "Rod Vagg <r@va.gg> (https://github.com/rvagg)",
   "license": "MIT",
   "dependencies": {
+    "inherits": "^2.0.4",
     "readable-stream": "2 || 3"
   },
   "devDependencies": {

--- a/through2.js
+++ b/through2.js
@@ -1,5 +1,5 @@
 var Transform = require('readable-stream').Transform
-  , inherits  = require('util').inherits
+  , inherits  = require('inherits')
 
 function DestroyableTransform(opts) {
   Transform.call(this, opts)


### PR DESCRIPTION
Webpack (and react-native) doesn't support node globals / global modules. This pull request removes the `util` global dependency and replaces it with [`inherits`](https://www.npmjs.com/package/inherits) which implements inherits just as node does, but works without globals.

_Note:_ I am sure about the version range of inherits to be used. Used "^2.0.4" for the moment.