### PR TITLE
Update through2.js

### DIFF
--- a/through2.js
+++ b/through2.js
@@ -1,4 +1,4 @@
-const { Transform } = require('readable-stream')
+const Transform = require('readable-stream').Transform
 
 function inherits (fn, sup) {
   fn.super_ = sup


### PR DESCRIPTION
this syntax doesn't break on older node versions