### PR TITLE
Change Polendina dev dependency to optional for complete installation on z/OS platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "chai": "^4.2.0",
     "hundreds": "~0.0.7",
     "mocha": "^7.2.0",
-    "polendina": "^1.0.0",
     "standard": "^14.3.4",
     "stream-spigot": "^3.0.6"
+  },
+  "optionalDependencies": {
+    "polendina": "^1.0.0"
   }
 }


### PR DESCRIPTION
Polendina has a dependency on puppeteer which does not recognize os390 as a valid platform, thus modifying package.json and changing polendina's dependency as optional would allow users with on a z/OS platform to install and use through2. 

Furthermore, even with this modification the citgm test of through2 passes, as citgm avoids browser testing. Citgm uses the script test:node to test through2 module, and  with the polendina module set as an optional dependency (and not puppeteer failing installation) the tests from test:node script pass on os390.